### PR TITLE
fix: disabled pattern-matching for string.find()

### DIFF
--- a/cve-2020-16899.lua
+++ b/cve-2020-16899.lua
@@ -14,7 +14,7 @@ function match(args)
     -- SCPacketPayload starts at byte 5 of the ICMPv6 header, so we use the packet buffer instead.
     local buffer = SCPacketPayload()
     local search_str = string.sub(buffer, 1, 8)
-    local s, _ = string.find(packet, search_str)
+    local s, _ = string.find(packet, search_str, 1, true)
     local offset = s - 4
 
     -- Only inspect Router Advertisement (Type = 134) ICMPv6 packets.


### PR DESCRIPTION
same as https://github.com/advanced-threat-research/CVE-2020-16898/pull/2